### PR TITLE
only include "twounter" when available

### DIFF
--- a/somerandomdude/footer.php
+++ b/somerandomdude/footer.php
@@ -7,12 +7,14 @@
 </div>
 <div id="page_bottom" class="clearfix">
 	<footer id='page_footer' class='container'>
-		<div class="row">	
+		<div class="row">
 		<?php if ( !function_exists('dynamic_sidebar') || !dynamic_sidebar("Footer") ) : ?>
-			
+
 		<?php endif; ?>
 		<div id="twitter_follow" class='six columns'>
-			<p><?php echo twounter('somerandomdude') ?> people follow me on Twitter. <a href="http://twitter.com/somerandomdude" class="button alt">You should too.</a></p>
+			<?php if ( function_exists('twounter') ) : ?>
+				<p><?php echo twounter('somerandomdude') ?> people follow me on Twitter. <a href="http://twitter.com/somerandomdude" class="button alt">You should too.</a></p>
+			<?php endif; ?>
 			<small>P.J. Onori <em><a href='http://creativecommons.org/licenses/by-sa/3.0/'>Licensed under Creative Commons Attribution-ShareAlike 3.0 Unported.</a></em></small>
 		</div>
 		</div>
@@ -25,7 +27,7 @@
 	<script src="<?php echo get_stylesheet_directory_uri(); ?>/js/main.js"></script>
 <?php else : ?>
 	<script async src="<?php echo get_stylesheet_directory_uri(); ?>/js/somerandomdude.js"></script>
-<?php endif; ?>	
+<?php endif; ?>
 
 </body>
 </html>


### PR DESCRIPTION
Hey,

the footer template gave me an error because I didn't have "twounter" installed. 

I wrapped the function call in a condition so that "twounter" is only called when the function is actually available.

… and there were some trailing whitespaces. ;-)

– Dominik
