### PR TITLE
Remove queries caused by widgets without autoloaded default options

### DIFF
--- a/frank/functions.php
+++ b/frank/functions.php
@@ -126,6 +126,8 @@ function frank_widgets() {
 
 
 // Clean up widget settings that weren't set at installation
+// If never used in a sidebar, their lack of default options will
+// trigger queries every page load
 add_action( 'after_switch_theme', 'frank_set_missing_widget_options' );
 function frank_set_missing_widget_options( ){
 	add_option( 'widget_pages', array ( '_multiwidget' => 1 ) );


### PR DESCRIPTION
Hi there,

I finally found the root cause of those extra queries added by some widgets. You can read my full explanation here:

http://wordpress.stackexchange.com/a/82420/9350

TL;DR: Other widgets have default options autoloaded except these four, which keep querying for defaults that aren't there.
