### PR TITLE
fixed url to variables partial.

### DIFF
--- a/frank/stylesheets/scss/print.scss
+++ b/frank/stylesheets/scss/print.scss
@@ -1,4 +1,4 @@
-@import "variables";
+@import "partials/variables";
 
 @media print {
 	body {


### PR DESCRIPTION
Just a quick fix for an error when converting the print Sass stylesheet to CSS caused by an incorrect url to the variables partial.
